### PR TITLE
Fix add buttons #100

### DIFF
--- a/editor.xhtml
+++ b/editor.xhtml
@@ -468,11 +468,26 @@
                                         </div>
                                     </xf:repeat>
 
+<!-- Heading for Roman names section visible even if there are none -->
+                                    <div class="tp-row">
+                                            <h4 class="tp-row tp-form-header col-md-2">Roman Name</h4>
+                                                <div class="tp-button-row tp-add">
+                                                    <label>Add Roman name</label>
+                                                    <xf:trigger class="-btn -btn-default">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-plus"/>
+                                                        </xf:label>
+                                                        <xf:insert context="//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type='Roman']"/>
+                                                        <script>
+                                                            clearAndInitAutocompletes();
+                                                        </script>
+                                                    </xf:trigger>
+                                                </div>
+                                    </div>
+<!-- Roman names heading end -->
+                                    
                                     <!-- Roman names -->
                                     <xf:repeat ref="TEI:listNym/TEI:nym[@type='Roman']" id="r-rname">
-                                        <xf:label class="tp-row tp-form-header">
-                                            <h4 class="col-md-2">Roman Name</h4>
-                                        </xf:label>
                                         <div class="tp-row">
                                             <xf:group ref=".">
                                                 <div class="tp-form-group-col">
@@ -1176,6 +1191,26 @@
 
                                 <div class="tp-section-divider"/>
 
+
+<!-- Heading for secondary sources section visible even if there are none -->
+                                    <div class="tp-row">
+                                            <h3 class="tp-form-header">Secondary sources</h3>
+                                                <div class="tp-button-row tp-add">
+                                                    <label>Add source</label>
+                                                    <xf:trigger class="-btn -btn-default ">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-plus"/>
+                                                        </xf:label>
+                                                        <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type = 'auxiliary']"/>
+                                                        <script>
+                                                            clearAndInitAutocompletes();
+                                                        </script>
+                                                    </xf:trigger>
+                                                </div>
+                                    </div>
+<!-- secondary sources heading end -->
+
+
                                 <!-- SECONDARY SOURCES -->
                                 <xf:group>
                                     <xf:repeat ref="TEI:bibl[@type = 'auxiliary']" id="r-auxiliary">
@@ -1291,6 +1326,7 @@
                 </div>
             </section>
             <!-- // end section names -->
+                                <div class="tp-section-divider"/>
 
             <!-- begin section relationships -->
             <section class="tp-section">

--- a/editor.xhtml
+++ b/editor.xhtml
@@ -124,7 +124,6 @@
             <div class="tp-row">
                 <h1 class="tp-column-fullwidth tp-headline">LGPN Person Input Form</h1>
             </div>
-
         </header>
 
         <main>
@@ -262,10 +261,30 @@
 
                                 <!-- NAME -->
                                 <xf:group>
+                                    <xf:label class="tp-form-header">
+                                        <h3 class="col-md-2">Nym</h3>
+                                    </xf:label>
+
                                     <xf:repeat ref="TEI:listNym/TEI:nym[@type!='Roman']" id="r-name">
-                                        <xf:label class="tp-row tp-form-header">
-                                            <h4 class="col-md-2">Nym</h4>
-                                        </xf:label>
+                                        <div class="tp-row tp-repeat-add">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Nym</h4>
+                                            </xf:label>
+                                            <div class="tp-repeat-button-left">
+                                                <div class="tp-button-row tp-add">
+                                                    <label>Add nym</label>
+                                                    <xf:trigger class="-btn -btn-default">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-plus"/>
+                                                        </xf:label>
+                                                        <xf:insert context="instance('i-default')//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type!='Roman']"/>
+                                                        <script>
+                                                            clearAndInitAutocompletes();
+                                                        </script>
+                                                    </xf:trigger>
+                                                </div>
+                                            </div>
+                                        </div>
 
                                         <xf:group ref=".">
                                            <div class="tp-row">
@@ -338,20 +357,6 @@
                                                 </div>
                                            </div>
                                             <div class="tp-row tp-repeat-buttons">
-                                                <div class="tp-repeat-button-left">
-                                                    <div class="tp-button-row tp-add">
-                                                        <label>Add nym</label>
-                                                        <xf:trigger class="-btn -btn-default">
-                                                            <xf:label class="input-group-addon">
-                                                                <i class="glyphicon glyphicon-plus"/>
-                                                            </xf:label>
-                                                            <xf:insert context="instance('i-default')//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type!='Roman']"/>
-                                                            <script>
-                                                                clearAndInitAutocompletes();
-                                                            </script>
-                                                        </xf:trigger>
-                                                    </div>
-                                                </div>
                                                 <div class="tp-repeat-button-right">
                                                     <div class="tp-button-row tp-delete">
                                                         <label>Delete nym</label>
@@ -369,10 +374,29 @@
 
                                         <!-- Attested forms -->
                                         <div>
+                                            <xf:label class="tp-form-header">
+                                                <h4 class="col-md-2">Attested Form</h4>
+                                            </xf:label>
                                             <xf:repeat ref="TEI:form[@type='attested']" id="r-nameForm">
-                                                <xf:label class="tp-row tp-form-header">
-                                                    <h4 class="col-md-2">Attested Form</h4>
-                                                </xf:label>
+                                                <div class="tp-row tp-repeat-add">
+                                                    <xf:label class="tp-row tp-form-header">
+                                                        <h4>Attested Form</h4>
+                                                    </xf:label>
+                                                    <div class="tp-repeat-button-left">
+                                                        <div class="tp-button-row tp-add">
+                                                            <label>Add attested form</label>
+                                                            <xf:trigger class="-btn -btn-default">
+                                                                <xf:label class="input-group-addon">
+                                                                    <i class="glyphicon glyphicon-plus"/>
+                                                                </xf:label>
+                                                                <xf:insert context="instance('i-default')//TEI:nym[@type!='Roman'][index('r-name')]" nodeset="TEI:form" origin="instance('i-template')//TEI:form[@type='attested']"/>
+                                                                <script>
+                                                                    clearAndInitAutocompletes();
+                                                                </script>
+                                                            </xf:trigger>
+                                                        </div>
+                                                    </div>
+                                                </div>
                                                 <xf:group ref=".">
                                                     <xf:label/>
                                                 </xf:group>
@@ -436,20 +460,6 @@
                                                 </div>
 
                                                 <div class="tp-row tp-repeat-buttons">
-                                                    <div class="tp-repeat-button-left">
-                                                        <div class="tp-button-row tp-add">
-                                                            <label>Add attested form</label>
-                                                            <xf:trigger class="-btn -btn-default">
-                                                                <xf:label class="input-group-addon">
-                                                                    <i class="glyphicon glyphicon-plus"/>
-                                                                </xf:label>
-                                                                <xf:insert context="instance('i-default')//TEI:nym[@type!='Roman'][index('r-name')]" nodeset="TEI:form" origin="instance('i-template')//TEI:form[@type='attested']"/>
-                                                                <script>
-                                                                    clearAndInitAutocompletes();
-                                                                </script>
-                                                            </xf:trigger>
-                                                        </div>
-                                                    </div>
                                                     <div class="tp-repeat-button-right">
                                                         <div class="tp-button-row tp-delete">
                                                             <label>Delete attested form</label>
@@ -468,27 +478,29 @@
                                         </div>
                                     </xf:repeat>
 
-<!-- Heading for Roman names section visible even if there are none -->
-                                    <div class="tp-row">
-                                            <h4 class="tp-row tp-form-header col-md-2">Roman Name</h4>
-                                                <div class="tp-button-row tp-add">
-                                                    <label>Add Roman name</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-plus"/>
-                                                        </xf:label>
-                                                        <xf:insert context="//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type='Roman']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                    </div>
-<!-- Roman names heading end -->
-                                    
                                     <!-- Roman names -->
                                     <xf:repeat ref="TEI:listNym/TEI:nym[@type='Roman']" id="r-rname">
                                         <div class="tp-row">
+                                            <div class="tp-row tp-repeat-add">
+                                                <xf:label class="tp-form-header">
+                                                    <h4>Roman Name</h4>
+                                                </xf:label>
+                                                <div class="tp-repeat-button-left">
+                                                    <div class="tp-button-row tp-add">
+                                                        <label>Add Roman name</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-plus"/>
+                                                            </xf:label>
+                                                            <xf:insert context="//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type='Roman']"/>
+                                                            <script>
+                                                                clearAndInitAutocompletes();
+                                                            </script>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+
                                             <xf:group ref=".">
                                                 <div class="tp-form-group-col">
                                                     <label class="tp-label" tooltip="ref">Praenomen</label>
@@ -557,20 +569,6 @@
                                         </div>
 
                                         <div class="tp-row tp-repeat-buttons">
-                                            <div class="tp-repeat-button-left">
-                                                <div class="tp-button-row tp-add">
-                                                    <label>Add Roman name</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-plus"/>
-                                                        </xf:label>
-                                                        <xf:insert context="//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type='Roman']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
                                             <div class="tp-repeat-button-right">
                                                 <div class="tp-button-row tp-delete">
                                                     <label>Delete Roman name</label>
@@ -583,8 +581,7 @@
                                                 </div>
                                             </div>
                                         </div>
-
-                                <div class="tp-section-divider"/>
+                                        <div class="tp-section-divider"/>
                                     </xf:repeat>
 
                                 </xf:group>
@@ -593,9 +590,25 @@
                                 <!-- Primary Sources -->
                                 <xf:group>
                                     <xf:repeat ref="TEI:bibl[@type='primary']" id="r-primarySource">
-                                        <xf:label>
-                                            <h3>Primary sources</h3>
-                                        </xf:label>
+                                        <div class="tp-row tp-repeat-add">
+                                            <xf:label>
+                                                <h3>Primary sources</h3>
+                                            </xf:label>
+                                            <div class="tp-repeat-button-left">
+                                                <div class="tp-button-row tp-add">
+                                                    <label>Add Source</label>
+                                                    <xf:trigger class="-btn -btn-default ">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-plus"/>
+                                                        </xf:label>
+                                                        <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type='primary']"/>
+                                                        <script>
+                                                            clearAndInitAutocompletes();
+                                                        </script>
+                                                    </xf:trigger>
+                                                </div>
+                                            </div>
+                                        </div>
                                         <xf:group ref=".">
                                             <xf:label/>
                                             <div class="tp-row">
@@ -728,20 +741,6 @@
                                             </div>
                                         </xf:group>
                                         <div class="tp-row tp-repeat-buttons">
-                                            <div class="tp-repeat-button-left">
-                                                <div class="tp-button-row tp-add">
-                                                    <label>Add Source</label>
-                                                    <xf:trigger class="-btn -btn-default ">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-plus"/>
-                                                        </xf:label>
-                                                        <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type='primary']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
                                             <div class="tp-repeat-button-right">
                                                 <div class="tp-button-row tp-delete">
                                                     <label>Delete Source</label>

--- a/editor.xhtml
+++ b/editor.xhtml
@@ -261,29 +261,31 @@
 
                                 <!-- NAME -->
                                 <xf:group>
-                                    <xf:label class="tp-form-header">
-                                        <h3 class="col-md-2">Nym</h3>
-                                    </xf:label>
+                                    <div class="tp-row tp-repeat-add">
+                                        <xf:label class="tp-form-header">
+                                            <h3>Nym</h3>
+                                        </xf:label>
+                                        <div class="tp-repeat-button-left">
+                                            <div class="tp-button-row tp-add">
+                                                <label>Add nym</label>
+                                                <xf:trigger class="-btn -btn-default">
+                                                    <xf:label class="input-group-addon">
+                                                        <i class="glyphicon glyphicon-plus"/>
+                                                    </xf:label>
+                                                    <xf:insert context="instance('i-default')//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type!='Roman']"/>
+                                                    <script>
+                                                        clearAndInitAutocompletes();
+                                                    </script>
+                                                </xf:trigger>
+                                            </div>
+                                        </div>
+                                    </div>
 
                                     <xf:repeat ref="TEI:listNym/TEI:nym[@type!='Roman']" id="r-name">
-                                        <div class="tp-row tp-repeat-add">
+                                        <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Nym</h4>
+                                                <h4>Nym Replicant</h4>
                                             </xf:label>
-                                            <div class="tp-repeat-button-left">
-                                                <div class="tp-button-row tp-add">
-                                                    <label>Add nym</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-plus"/>
-                                                        </xf:label>
-                                                        <xf:insert context="instance('i-default')//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type!='Roman']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
                                         </div>
 
                                         <xf:group ref=".">
@@ -374,28 +376,31 @@
 
                                         <!-- Attested forms -->
                                         <div>
-                                            <xf:label class="tp-form-header">
-                                                <h4 class="col-md-2">Attested Form</h4>
-                                            </xf:label>
-                                            <xf:repeat ref="TEI:form[@type='attested']" id="r-nameForm">
-                                                <div class="tp-row tp-repeat-add">
-                                                    <xf:label class="tp-row tp-form-header">
-                                                        <h4>Attested Form</h4>
-                                                    </xf:label>
-                                                    <div class="tp-repeat-button-left">
-                                                        <div class="tp-button-row tp-add">
-                                                            <label>Add attested form</label>
-                                                            <xf:trigger class="-btn -btn-default">
-                                                                <xf:label class="input-group-addon">
-                                                                    <i class="glyphicon glyphicon-plus"/>
-                                                                </xf:label>
-                                                                <xf:insert context="instance('i-default')//TEI:nym[@type!='Roman'][index('r-name')]" nodeset="TEI:form" origin="instance('i-template')//TEI:form[@type='attested']"/>
-                                                                <script>
-                                                                    clearAndInitAutocompletes();
-                                                                </script>
-                                                            </xf:trigger>
-                                                        </div>
+                                            <div class="tp-row tp-repeat-add">
+                                                <xf:label class="tp-form-header">
+                                                    <h3>Attested Form</h3>
+                                                </xf:label>
+                                                <div class="tp-repeat-button-left">
+                                                    <div class="tp-button-row tp-add">
+                                                        <label>Add attested form</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-plus"/>
+                                                            </xf:label>
+                                                            <xf:insert context="instance('i-default')//TEI:nym[@type!='Roman'][index('r-name')]" nodeset="TEI:form" origin="instance('i-template')//TEI:form[@type='attested']"/>
+                                                            <script>
+                                                                clearAndInitAutocompletes();
+                                                            </script>
+                                                        </xf:trigger>
                                                     </div>
+                                                </div>
+                                            </div>
+
+                                            <xf:repeat ref="TEI:form[@type='attested']" id="r-nameForm">
+                                                <div class="tp-row tp-repeat-headline">
+                                                    <xf:label class="tp-form-header">
+                                                        <h4>Attested Form Replicant</h4>
+                                                    </xf:label>
                                                 </div>
                                                 <xf:group ref=".">
                                                     <xf:label/>
@@ -479,129 +484,19 @@
                                     </xf:repeat>
 
                                     <!-- Roman names -->
-                                    <xf:repeat ref="TEI:listNym/TEI:nym[@type='Roman']" id="r-rname">
-                                        <div class="tp-row">
-                                            <div class="tp-row tp-repeat-add">
-                                                <xf:label class="tp-form-header">
-                                                    <h4>Roman Name</h4>
-                                                </xf:label>
-                                                <div class="tp-repeat-button-left">
-                                                    <div class="tp-button-row tp-add">
-                                                        <label>Add Roman name</label>
-                                                        <xf:trigger class="-btn -btn-default">
-                                                            <xf:label class="input-group-addon">
-                                                                <i class="glyphicon glyphicon-plus"/>
-                                                            </xf:label>
-                                                            <xf:insert context="//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type='Roman']"/>
-                                                            <script>
-                                                                clearAndInitAutocompletes();
-                                                            </script>
-                                                        </xf:trigger>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            <xf:group ref=".">
-                                                <div class="tp-form-group-col">
-                                                    <label class="tp-label" tooltip="ref">Praenomen</label>
-                                                    <xf:input ref="TEI:persName[@type='praenomen']" class="hidden">
-                                                        <xf:action ev:event="nyms_autocomplete-callback">
-                                                            <xf:setvalue ref="." value="event('termValue')"/>
-                                                        </xf:action>
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-book"/>
-                                                        </xf:label>
-                                                        <xf:hint>praenomen</xf:hint>
-                                                    </xf:input>
-                                                    <input type="hidden" class="tp-input" data-function="nyms_autocomplete" placeholder="Type to search praenomen" autocomplete="off"/>
-                                                </div>
-                                                <div class="tp-form-group-col">
-                                                    <label class="tp-label" tooltip="ref">Nomen gentile</label>
-                                                    <xf:input ref="TEI:persName[@type='nomen_gentile']" class="hidden">
-                                                        <xf:action ev:event="nyms_autocomplete-callback">
-                                                            <xf:setvalue ref="." value="event('termValue')"/>
-                                                        </xf:action>
-                                                        <xf:label class="input-group-addon">ref
-                                                            <i class="glyphicon glyphicon-book"/>
-                                                        </xf:label>
-                                                        <xf:hint>nomen gentile</xf:hint>
-                                                    </xf:input>
-                                                    <input type="hidden" class="tp-input" data-function="nyms_autocomplete" placeholder="Type to search nomen gentile" autocomplete="off"/>
-                                                </div>
-                                                <div class="tp-form-group-col">
-                                                    <label class="tp-label">Relationship</label>
-                                                    <xf:select1 class="tp-input -form-control" ref="TEI:persName[@type='filiation']/@subtype">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-list"/>
-                                                        </xf:label>
-                                                        <xf:itemset nodeset="instance('i-filiation')/option">
-                                                            <xf:label ref="."/>
-                                                            <xf:value ref="@value"/>
-                                                        </xf:itemset>
-                                                    </xf:select1>
-                                                </div>
-                                                <div class="tp-form-group-col">
-                                                    <label class="tp-label" tooltip="ref">Search relationship</label>
-                                                    <xf:input ref="TEI:persName[@type='filiation']" class="hidden">
-                                                        <xf:action ev:event="nyms_autocomplete-callback">
-                                                            <xf:setvalue ref="." value="event('termValue')"/>
-                                                        </xf:action>
-                                                        <xf:label class="input-group-addon">ref
-                                                            <i class="glyphicon glyphicon-book"/>
-                                                        </xf:label>
-                                                        <xf:hint>filiation</xf:hint>
-                                                    </xf:input>
-                                                    <input type="hidden" class="tp-input" data-function="nyms_autocomplete" placeholder="Type to search filiation" autocomplete="off"/>
-                                                </div>
-                                                <div class="tp-form-group-col">
-                                                    <label class="tp-label" tooltip="ref">Tribes</label>
-                                                    <xf:select1 class="tp-input -form-control" ref="TEI:persName[@type='tribe']">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-list"/>
-                                                        </xf:label>
-                                                        <xf:itemset nodeset="instance('i-tribes')/option">
-                                                            <xf:label ref="."/>
-                                                            <xf:value ref="@value"/>
-                                                        </xf:itemset>
-                                                    </xf:select1>
-                                                </div>
-                                            </xf:group>
-                                        </div>
-
-                                        <div class="tp-row tp-repeat-buttons">
-                                            <div class="tp-repeat-button-right">
-                                                <div class="tp-button-row tp-delete">
-                                                    <label>Delete Roman name</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-trash"/>
-                                                        </xf:label>
-                                                        <xf:delete nodeset="//TEI:nym[@type='Roman'][index('r-rname')]"/>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="tp-section-divider"/>
-                                    </xf:repeat>
-
-                                </xf:group>
-
-
-                                <!-- Primary Sources -->
-                                <xf:group>
-                                    <xf:repeat ref="TEI:bibl[@type='primary']" id="r-primarySource">
+                                    <div>
                                         <div class="tp-row tp-repeat-add">
-                                            <xf:label>
-                                                <h3>Primary sources</h3>
+                                            <xf:label class="tp-form-header">
+                                                <h3>Roman Name</h3>
                                             </xf:label>
                                             <div class="tp-repeat-button-left">
                                                 <div class="tp-button-row tp-add">
-                                                    <label>Add Source</label>
-                                                    <xf:trigger class="-btn -btn-default ">
+                                                    <label>Add Roman name</label>
+                                                    <xf:trigger class="-btn -btn-default">
                                                         <xf:label class="input-group-addon">
                                                             <i class="glyphicon glyphicon-plus"/>
                                                         </xf:label>
-                                                        <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type='primary']"/>
+                                                        <xf:insert context="//TEI:listNym" nodeset="TEI:nym" origin="instance('i-template')//TEI:nym[@type='Roman']"/>
                                                         <script>
                                                             clearAndInitAutocompletes();
                                                         </script>
@@ -609,6 +504,131 @@
                                                 </div>
                                             </div>
                                         </div>
+
+                                        <xf:repeat ref="TEI:listNym/TEI:nym[@type='Roman']" id="r-rname">
+                                            <div class="tp-row">
+                                                <div class="tp-row tp-repeat-headline">
+                                                    <xf:label class="tp-form-header">
+                                                        <h4 class="col-md-6">Roman Name Replicant</h4>
+                                                    </xf:label>
+                                                </div>
+
+                                                <xf:group ref=".">
+                                                    <div class="tp-form-group-col">
+                                                        <label class="tp-label" tooltip="ref">Praenomen</label>
+                                                        <xf:input ref="TEI:persName[@type='praenomen']" class="hidden">
+                                                            <xf:action ev:event="nyms_autocomplete-callback">
+                                                                <xf:setvalue ref="." value="event('termValue')"/>
+                                                            </xf:action>
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-book"/>
+                                                            </xf:label>
+                                                            <xf:hint>praenomen</xf:hint>
+                                                        </xf:input>
+                                                        <input type="hidden" class="tp-input" data-function="nyms_autocomplete" placeholder="Type to search praenomen" autocomplete="off"/>
+                                                    </div>
+                                                    <div class="tp-form-group-col">
+                                                        <label class="tp-label" tooltip="ref">Nomen gentile</label>
+                                                        <xf:input ref="TEI:persName[@type='nomen_gentile']" class="hidden">
+                                                            <xf:action ev:event="nyms_autocomplete-callback">
+                                                                <xf:setvalue ref="." value="event('termValue')"/>
+                                                            </xf:action>
+                                                            <xf:label class="input-group-addon">ref
+                                                                <i class="glyphicon glyphicon-book"/>
+                                                            </xf:label>
+                                                            <xf:hint>nomen gentile</xf:hint>
+                                                        </xf:input>
+                                                        <input type="hidden" class="tp-input" data-function="nyms_autocomplete" placeholder="Type to search nomen gentile" autocomplete="off"/>
+                                                    </div>
+                                                    <div class="tp-form-group-col">
+                                                        <label class="tp-label">Relationship</label>
+                                                        <xf:select1 class="tp-input -form-control" ref="TEI:persName[@type='filiation']/@subtype">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-list"/>
+                                                            </xf:label>
+                                                            <xf:itemset nodeset="instance('i-filiation')/option">
+                                                                <xf:label ref="."/>
+                                                                <xf:value ref="@value"/>
+                                                            </xf:itemset>
+                                                        </xf:select1>
+                                                    </div>
+                                                    <div class="tp-form-group-col">
+                                                        <label class="tp-label" tooltip="ref">Search relationship</label>
+                                                        <xf:input ref="TEI:persName[@type='filiation']" class="hidden">
+                                                            <xf:action ev:event="nyms_autocomplete-callback">
+                                                                <xf:setvalue ref="." value="event('termValue')"/>
+                                                            </xf:action>
+                                                            <xf:label class="input-group-addon">ref
+                                                                <i class="glyphicon glyphicon-book"/>
+                                                            </xf:label>
+                                                            <xf:hint>filiation</xf:hint>
+                                                        </xf:input>
+                                                        <input type="hidden" class="tp-input" data-function="nyms_autocomplete" placeholder="Type to search filiation" autocomplete="off"/>
+                                                    </div>
+                                                    <div class="tp-form-group-col">
+                                                        <label class="tp-label" tooltip="ref">Tribes</label>
+                                                        <xf:select1 class="tp-input -form-control" ref="TEI:persName[@type='tribe']">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-list"/>
+                                                            </xf:label>
+                                                            <xf:itemset nodeset="instance('i-tribes')/option">
+                                                                <xf:label ref="."/>
+                                                                <xf:value ref="@value"/>
+                                                            </xf:itemset>
+                                                        </xf:select1>
+                                                    </div>
+                                                </xf:group>
+                                            </div>
+
+                                            <div class="tp-row tp-repeat-buttons">
+                                                <div class="tp-repeat-button-right">
+                                                    <div class="tp-button-row tp-delete">
+                                                        <label>Delete Roman name</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-trash"/>
+                                                            </xf:label>
+                                                            <xf:delete nodeset="//TEI:nym[@type='Roman'][index('r-rname')]"/>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="tp-section-divider"/>
+                                        </xf:repeat>
+                                    </div>
+
+                                </xf:group>
+
+
+                                <!-- Primary Sources -->
+                                <xf:group>
+                                    <div class="tp-row tp-repeat-add">
+                                        <xf:label class="tp-form-header">
+                                            <h3>Primary sources</h3>
+                                        </xf:label>
+                                        <div class="tp-repeat-button-left">
+                                            <div class="tp-button-row tp-add">
+                                                <label>Add Source</label>
+                                                <xf:trigger class="-btn -btn-default">
+                                                    <xf:label class="input-group-addon">
+                                                        <i class="glyphicon glyphicon-plus"/>
+                                                    </xf:label>
+                                                    <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type='primary']"/>
+                                                    <script>
+                                                        clearAndInitAutocompletes();
+                                                    </script>
+                                                </xf:trigger>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <xf:repeat ref="TEI:bibl[@type='primary']" id="r-primarySource">
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Primary Sources Replicant</h4>
+                                            </xf:label>
+                                        </div>
+
                                         <xf:group ref=".">
                                             <xf:label/>
                                             <div class="tp-row">
@@ -760,10 +780,32 @@
 
                                 <!-- PLACES -->
                                 <xf:group>
-                                    <xf:repeat ref="TEI:state[@type='location']" id="r-place">
-                                        <xf:label class="tp-row tp-form-header">
-                                            <h3 class="col-md-2">Places</h3>
+                                    <div class="tp-row tp-repeat-add">
+                                        <xf:label class="tp-form-header">
+                                            <h3>Places</h3>
                                         </xf:label>
+                                        <div class="tp-repeat-button-left">
+                                            <div class="tp-button-row tp-add">
+                                                <label>Add place</label>
+                                                <xf:trigger class="-btn -btn-default ">
+                                                    <xf:label class="input-group-addon">
+                                                        <i class="glyphicon glyphicon-plus"/>
+                                                    </xf:label>
+                                                    <xf:insert context="//TEI:person" nodeset="TEI:state" origin="instance('i-template')//TEI:state[@type='location']"/>
+                                                    <script>
+                                                        clearAndInitAutocompletes();
+                                                    </script>
+                                                </xf:trigger>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <xf:repeat ref="TEI:state[@type='location']" id="r-place">
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Places Replicant</h4>
+                                            </xf:label>
+                                        </div>
                                         <xf:group ref=".">
                                             <xf:label/>
                                             <div class="tp-row">
@@ -842,21 +884,6 @@
                                             </div>
                                         </xf:group>
                                         <div class="tp-row tp-repeat-buttons">
-                                            <div class="tp-repeat-button-left">
-                                                <div class="tp-button-row tp-add">
-                                                    <label>Add place</label>
-                                                    <xf:trigger class="-btn -btn-default ">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-plus"/>
-                                                        </xf:label>
-                                                        <xf:insert context="//TEI:person" nodeset="TEI:state" origin="instance('i-template')//TEI:state[@type='location']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-
                                             <div class="tp-repeat-button-right">
                                                 <div class="tp-button-row tp-delete">
                                                     <label>Delete place</label>
@@ -871,461 +898,478 @@
                                         </div>
                                         <div class="tp-section-divider"/>
                                     </xf:repeat>
-
                                 </xf:group>
 
-
-                                <h3>Status</h3>
-
-                                <xf:repeat ref="//TEI:trait[@type='status']" id="r-status">
-                                    <xf:label/>
-                                    <xf:group ref=".">
-                                        <div class="tp-row">
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Status</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@key">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tag"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-status')/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Subcategory</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@ana">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tags"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-status')/TEI:category[@xml:id=current()/../@key]/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                        </div>
-
-                                        <div class="tp-row tp-repeat-buttons">
+                                <section class="status-section">
+                                    <section class="tp-row tp-repeat-add">
+                                        <xf:label class="tp-form-header">
+                                            <h3 class="status-headline">Status</h3>
+                                        </xf:label>
+                                        <div class="tp-row status-button-container">
                                             <div class="tp-repeat-button-left">
                                                 <div class="tp-button-row tp-add">
-                                                    <label>Add Status</label>
+                                                    <label><span>Add </span>Status</label>
                                                     <xf:trigger class="-btn -btn-default ">
                                                         <xf:label class="input-group-addon">
                                                             <i class="glyphicon glyphicon-plus"/>
                                                         </xf:label>
                                                         <xf:insert context="//TEI:person" nodeset="TEI:trait" origin="instance('i-template')//TEI:trait[@type='status']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
+                                                        <script>clearAndInitAutocompletes();</script>
                                                     </xf:trigger>
                                                 </div>
                                             </div>
-                                            <div class="tp-repeat-button-right">
-                                                <div class="tp-button-row tp-delete">
-                                                    <label>Delete Status</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-trash"/>
-                                                        </xf:label>
-                                                        <xf:delete nodeset="//TEI:trait[@type='status'][index('r-status')]"/>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-
-                                        </div>
-                                    </xf:group>
-                                </xf:repeat>
-
-                                <div class="tp-divider col-xs-12"/>
-
-                                <xf:repeat ref="//TEI:trait[@type='profession']" id="r-profession">
-                                    <xf:label/>
-                                    <xf:group ref=".">
-                                        <div class="tp-row">
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Profession</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@key">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tag"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-profession')/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Subcategory</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@ana">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tags"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-profession')/TEI:category[@xml:id=current()/../@key]/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                        </div>
-
-                                        <div class="tp-row tp-repeat-buttons">
                                             <div class="tp-repeat-button-left">
                                                 <div class="tp-button-row tp-add">
-                                                    <label>Add Profession</label>
+                                                    <label><span>Add </span>Profession</label>
                                                     <xf:trigger class="-btn -btn-default ">
                                                         <xf:label class="input-group-addon">
                                                             <i class="glyphicon glyphicon-plus"/>
                                                         </xf:label>
                                                         <xf:insert context="//TEI:person" nodeset="TEI:trait" origin="instance('i-template')//TEI:trait[@type='profession']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
+                                                        <script>clearAndInitAutocompletes();</script>
                                                     </xf:trigger>
                                                 </div>
                                             </div>
-                                            <div class="tp-repeat-button-right">
-                                                <div class="tp-button-row tp-delete">
-                                                    <label>Delete Profession</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-trash"/>
-                                                        </xf:label>
-                                                        <xf:delete nodeset="//TEI:trait[@type='profession'][index('r-profession')]"/>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </xf:group>
-                                </xf:repeat>
-
-                                <div class="tp-divider col-xs-12"/>
-
-                                <xf:repeat ref="//TEI:trait[@type='office']" id="r-office">
-                                    <xf:label/>
-                                    <xf:group ref=".">
-                                        <div class="tp-row">
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Office</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@key">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tag"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-office')/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Subcategory</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@ana">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tags"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-office')/TEI:category[@xml:id=current()/../@key]/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                        </div>
-
-                                        <div class="tp-row tp-repeat-buttons">
                                             <div class="tp-repeat-button-left">
                                                 <div class="tp-button-row tp-add">
-                                                    <label>Add Office</label>
+                                                    <label><span>Add </span>Profession</label>
+                                                    <xf:trigger class="-btn -btn-default ">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-plus"/>
+                                                        </xf:label>
+                                                        <xf:insert context="//TEI:person" nodeset="TEI:trait" origin="instance('i-template')//TEI:trait[@type='profession']"/>
+                                                        <script>clearAndInitAutocompletes();</script>
+                                                    </xf:trigger>
+                                                </div>
+                                            </div>
+                                            <div class="tp-repeat-button-left">
+                                                <div class="tp-button-row tp-add">
+                                                    <label><span>Add </span>Office</label>
                                                     <xf:trigger class="-btn -btn-default ">
                                                         <xf:label class="input-group-addon">
                                                             <i class="glyphicon glyphicon-plus"/>
                                                         </xf:label>
                                                         <xf:insert context="//TEI:person" nodeset="TEI:trait" origin="instance('i-template')//TEI:trait[@type='office']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
+                                                        <script>clearAndInitAutocompletes();</script>
                                                     </xf:trigger>
                                                 </div>
                                             </div>
-                                            <div class="tp-repeat-button-right">
-                                                <div class="tp-button-row tp-delete">
-                                                    <label>Delete Office</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-trash"/>
-                                                        </xf:label>
-                                                        <xf:delete nodeset="//TEI:trait[@type='office'][index('r-office')]"/>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                    </xf:group>
-                                </xf:repeat>
-
-                                <div class="tp-divider col-xs-12"/>
-
-                                <xf:repeat ref="//TEI:trait[@type='religion']" id="r-religion">
-                                    <xf:label/>
-                                    <xf:group ref=".">
-                                        <div class="tp-row">
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Religion</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@key">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tag"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-religion')/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Subcategory</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@ana">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tags"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-religion')/TEI:category[@xml:id=current()/../@key]/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                        </div>
-
-                                        <div class="tp-row tp-repeat-buttons">
                                             <div class="tp-repeat-button-left">
                                                 <div class="tp-button-row tp-add">
-                                                    <label>Add Religion</label>
+                                                    <label><span>Add </span>Religion</label>
                                                     <xf:trigger class="-btn -btn-default ">
                                                         <xf:label class="input-group-addon">
                                                             <i class="glyphicon glyphicon-plus"/>
                                                         </xf:label>
                                                         <xf:insert context="//TEI:person" nodeset="TEI:trait" origin="instance('i-template')//TEI:trait[@type='religion']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
+                                                        <script>clearAndInitAutocompletes();</script>
                                                     </xf:trigger>
                                                 </div>
                                             </div>
-                                            <div class="tp-repeat-button-right">
-                                                <div class="tp-button-row tp-delete">
-                                                    <label>Delete Religion</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-trash"/>
-                                                        </xf:label>
-                                                        <xf:delete nodeset="//TEI:trait[@type='religion'][index('r-religion')]"/>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </xf:group>
-                                </xf:repeat>
-
-                                <div class="tp-divider col-xs-12"/>
-
-                                <xf:repeat ref="//TEI:trait[@type='Roman']" id="r-Roman">
-                                    <xf:label/>
-                                    <xf:group ref=".">
-                                        <div class="tp-row">
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Roman World</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@key">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tag"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-roman')/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Subcategory</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@ana">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-tags"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-roman')/TEI:category[@xml:id=current()/../@key]/TEI:category">
-                                                        <xf:label ref="TEI:catDesc"/>
-                                                        <xf:value ref="@xml:id"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
-                                        </div>
-
-                                        <div class="tp-row tp-repeat-buttons">
                                             <div class="tp-repeat-button-left">
                                                 <div class="tp-button-row tp-add">
-                                                    <label>Add Category</label>
+                                                    <label><span>Add </span>Category</label>
                                                     <xf:trigger class="-btn -btn-default ">
                                                         <xf:label class="input-group-addon">
                                                             <i class="glyphicon glyphicon-plus"/>
                                                         </xf:label>
                                                         <xf:insert context="//TEI:person" nodeset="TEI:trait" origin="instance('i-template')//TEI:trait[@type='Roman']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-                                            <div class="tp-repeat-button-right">
-                                                <div class="tp-button-row tp-delete">
-                                                    <label>Delete Category</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-trash"/>
-                                                        </xf:label>
-                                                        <xf:delete nodeset="//TEI:trait[@type='Roman'][index('r-Roman')]"/>
+                                                        <script>clearAndInitAutocompletes();</script>
                                                     </xf:trigger>
                                                 </div>
                                             </div>
                                         </div>
+                                    </section>
 
-                                    </xf:group>
-                                </xf:repeat>
+                                    <div class="tp-section-divider"/>
+
+                                    <xf:repeat ref="//TEI:trait[@type='status']" id="r-status">
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Status Replicant</h4>
+                                            </xf:label>
+                                        </div>
+
+                                        <xf:group ref=".">
+                                            <div class="tp-row">
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Status</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@key">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tag"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-status')/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Subcategory</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@ana">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tags"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-status')/TEI:category[@xml:id=current()/../@key]/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                            </div>
+
+                                            <div class="tp-row tp-repeat-buttons">
+                                                <div class="tp-repeat-button-right">
+                                                    <div class="tp-button-row tp-delete">
+                                                        <label>Delete Status</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-trash"/>
+                                                            </xf:label>
+                                                            <xf:delete nodeset="//TEI:trait[@type='status'][index('r-status')]"/>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </xf:group>
+                                    </xf:repeat>
+
+                                    <div class="tp-section-divider"/>
+
+                                    <xf:repeat ref="//TEI:trait[@type='profession']" id="r-profession">
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Profession Replicant</h4>
+                                            </xf:label>
+                                        </div>
+                                        <xf:group ref=".">
+                                            <div class="tp-row">
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Profession</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@key">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tag"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-profession')/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Subcategory</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@ana">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tags"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-profession')/TEI:category[@xml:id=current()/../@key]/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                            </div>
+
+                                            <div class="tp-row tp-repeat-buttons">
+                                                <div class="tp-repeat-button-right">
+                                                    <div class="tp-button-row tp-delete">
+                                                        <label>Delete Profession</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-trash"/>
+                                                            </xf:label>
+                                                            <xf:delete nodeset="//TEI:trait[@type='profession'][index('r-profession')]"/>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </xf:group>
+                                    </xf:repeat>
+
+                                    <div class="tp-section-divider"/>
+
+                                    <xf:repeat ref="//TEI:trait[@type='office']" id="r-office">
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Office Replicant</h4>
+                                            </xf:label>
+                                        </div>
+                                        <xf:group ref=".">
+                                            <div class="tp-row">
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Office</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@key">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tag"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-office')/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Subcategory</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@ana">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tags"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-office')/TEI:category[@xml:id=current()/../@key]/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                            </div>
+
+                                            <div class="tp-row tp-repeat-buttons">
+                                                <div class="tp-repeat-button-right">
+                                                    <div class="tp-button-row tp-delete">
+                                                        <label>Delete Office</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-trash"/>
+                                                            </xf:label>
+                                                            <xf:delete nodeset="//TEI:trait[@type='office'][index('r-office')]"/>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                        </xf:group>
+                                    </xf:repeat>
+
+                                    <div class="tp-section-divider"/>
+
+                                    <xf:repeat ref="//TEI:trait[@type='religion']" id="r-religion">
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Religion Replicant</h4>
+                                            </xf:label>
+                                        </div>
+                                        <xf:group ref=".">
+                                            <div class="tp-row">
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Religion</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@key">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tag"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-religion')/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Subcategory</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@ana">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tags"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-religion')/TEI:category[@xml:id=current()/../@key]/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                            </div>
+
+                                            <div class="tp-row tp-repeat-buttons">
+                                                <div class="tp-repeat-button-right">
+                                                    <div class="tp-button-row tp-delete">
+                                                        <label>Delete Religion</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-trash"/>
+                                                            </xf:label>
+                                                            <xf:delete nodeset="//TEI:trait[@type='religion'][index('r-religion')]"/>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </xf:group>
+                                    </xf:repeat>
+
+                                    <div class="tp-section-divider"/>
+
+                                    <xf:repeat ref="//TEI:trait[@type='Roman']" id="r-Roman">
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Roman World Replicant</h4>
+                                            </xf:label>
+                                        </div>
+                                        <xf:group ref=".">
+                                            <div class="tp-row">
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Roman World</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@key">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tag"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-roman')/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Subcategory</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@ana">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-tags"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-roman')/TEI:category[@xml:id=current()/../@key]/TEI:category">
+                                                            <xf:label ref="TEI:catDesc"/>
+                                                            <xf:value ref="@xml:id"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                            </div>
+
+                                            <div class="tp-row tp-repeat-buttons">
+                                                <div class="tp-repeat-button-right">
+                                                    <div class="tp-button-row tp-delete">
+                                                        <label>Delete Category</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-trash"/>
+                                                            </xf:label>
+                                                            <xf:delete nodeset="//TEI:trait[@type='Roman'][index('r-Roman')]"/>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </xf:group>
+                                    </xf:repeat>
+                                </section>
 
                                 <div class="tp-section-divider"/>
 
 
-<!-- Heading for secondary sources section visible even if there are none -->
-                                    <div class="tp-row">
-                                            <h3 class="tp-form-header">Secondary sources</h3>
-                                                <div class="tp-button-row tp-add">
-                                                    <label>Add source</label>
-                                                    <xf:trigger class="-btn -btn-default ">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-plus"/>
-                                                        </xf:label>
-                                                        <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type = 'auxiliary']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                    </div>
-<!-- secondary sources heading end -->
-
-
                                 <!-- SECONDARY SOURCES -->
-                                <xf:group>
-                                    <xf:repeat ref="TEI:bibl[@type = 'auxiliary']" id="r-auxiliary">
-                                        <xf:label>
+                                <section class="secondary-sources">
+                                    <div class="tp-row tp-repeat-add">
+                                        <xf:label class="tp-form-header">
                                             <h3>Secondary sources</h3>
                                         </xf:label>
-
-                                        <div class="tp-row">
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label" tooltip="ref">Reference Abbr.</label>
-                                                <xf:input class="hidden" ref="TEI:ref/@target">
-                                                    <xf:action ev:event="reference_autocomplete-callback">
-                                                        <xf:setvalue ref="." value="event('termValue')"/>
-                                                    </xf:action>
-                                                    <xf:label class="input-group-addon">ref
-                                                        <i class="glyphicon glyphicon-search"/>
+                                        <div class="tp-repeat-button-left">
+                                            <div class="tp-button-row tp-add">
+                                                <label>Add Source</label>
+                                                <xf:trigger class="-btn -btn-default">
+                                                    <xf:label class="input-group-addon">
+                                                        <i class="glyphicon glyphicon-plus"/>
                                                     </xf:label>
-                                                    <xf:hint>reference abbreviation</xf:hint>
-                                                </xf:input>
-                                                <input type="hidden" class="tp-input" data-function="reference_autocomplete" placeholder="Type to search reference abbreviation" autocomplete="off"/>
-                                                <xf:trigger class="hidden reference_autocomplete">
-                                                    <xf:label/>
-                                                    <xf:action ev:event="DOMActivate">
-                                                        <xf:setvalue ref="instance('i-controller')/bibl" value="instance('i-default')//TEI:bibl[index('r-primarySource')]/TEI:ref/@target"/>
-                                                        <xf:dispatch name="load-subform-event" targetid="load-subform-group"/>
-                                                    </xf:action>
+                                                    <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type = 'auxiliary']"/>
+                                                    <script>clearAndInitAutocompletes();</script>
                                                 </xf:trigger>
                                             </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Author</label>
-                                                <xf:input class="tp-input -form-control" ref="TEI:author">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-user"/>
-                                                    </xf:label>
-                                                </xf:input>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Details</label>
-                                                <xf:input class="tp-input -form-control" ref="TEI:seg[@type='details']">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-list-alt"/>
-                                                    </xf:label>
-                                                </xf:input>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Link</label>
-                                                <xf:input class="tp-input -form-control" ref="TEI:ptr/@ref">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-link"/>
-                                                    </xf:label>
-                                                </xf:input>
-                                            </div>
-                                            <div class="tp-form-group-col">
-                                                <label class="tp-label">Secondary Types</label>
-                                                <xf:select1 class="tp-input -form-control" ref="@subtype">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-book"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-secondaryTypes')/option">
-                                                        <xf:label ref="."/>
-                                                        <xf:value ref="@value"/>
-                                                    </xf:itemset>
-                                                </xf:select1>
-                                            </div>
                                         </div>
-                                        <div class="tp-row">
-                                            <div class="form-group">
-                                                <label class="tp-label-1-row-2-col">Source</label>
-                                                <xf:select class="tp-input-1-row-2-col" ref="@ana" appearance="full">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-check"/>
-                                                    </xf:label>
-                                                    <xf:itemset nodeset="instance('i-comments')//option">
-                                                        <xf:label ref="."/>
-                                                        <xf:value ref="@value"/>
-                                                    </xf:itemset>
-                                                </xf:select>
-                                            </div>
-                                        </div>
-                                        <div class="tp-row tp-repeat-buttons">
-                                            <div class="tp-repeat-button-left">
-                                                <div class="tp-button-row tp-add">
-                                                    <label>Add</label>
-                                                    <xf:trigger class="-btn -btn-default ">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-plus"/>
-                                                        </xf:label>
-                                                        <xf:insert context="//TEI:person" nodeset="TEI:bibl" origin="instance('i-template')//TEI:bibl[@type = 'auxiliary']"/>
-                                                        <script>
-                                                            clearAndInitAutocompletes();
-                                                        </script>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-                                            <div class="tp-repeat-button-right">
-                                                <div class="tp-button-row tp-delete">
-                                                    <label>Delete</label>
-                                                    <xf:trigger class="-btn -btn-default">
-                                                        <xf:label class="input-group-addon">
-                                                            <i class="glyphicon glyphicon-trash"/>
-                                                        </xf:label>
-                                                        <xf:delete nodeset="//TEI:bibl[@type = 'auxiliary'][index('r-auxiliary')]"/>
-                                                    </xf:trigger>
-                                                </div>
-                                            </div>
-                                        </div>
+                                    </div>
 
-                                    </xf:repeat>
-                                </xf:group>
+                                    <xf:group>
+                                        <xf:repeat ref="TEI:bibl[@type = 'auxiliary']" id="r-auxiliary">
+                                            <div class="tp-row tp-repeat-headline">
+                                                <xf:label class="tp-form-header">
+                                                    <h4>Secondary Sources Replicant</h4>
+                                                </xf:label>
+                                            </div>
+
+                                            <div class="tp-row">
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label" tooltip="ref">Reference Abbr.</label>
+                                                    <xf:input class="hidden" ref="TEI:ref/@target">
+                                                        <xf:action ev:event="reference_autocomplete-callback">
+                                                            <xf:setvalue ref="." value="event('termValue')"/>
+                                                        </xf:action>
+                                                        <xf:label class="input-group-addon">ref
+                                                            <i class="glyphicon glyphicon-search"/>
+                                                        </xf:label>
+                                                        <xf:hint>reference abbreviation</xf:hint>
+                                                    </xf:input>
+                                                    <input type="hidden" class="tp-input" data-function="reference_autocomplete" placeholder="Type to search reference abbreviation" autocomplete="off"/>
+                                                    <xf:trigger class="hidden reference_autocomplete">
+                                                        <xf:label/>
+                                                        <xf:action ev:event="DOMActivate">
+                                                            <xf:setvalue ref="instance('i-controller')/bibl" value="instance('i-default')//TEI:bibl[index('r-primarySource')]/TEI:ref/@target"/>
+                                                            <xf:dispatch name="load-subform-event" targetid="load-subform-group"/>
+                                                        </xf:action>
+                                                    </xf:trigger>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Author</label>
+                                                    <xf:input class="tp-input -form-control" ref="TEI:author">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-user"/>
+                                                        </xf:label>
+                                                    </xf:input>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Details</label>
+                                                    <xf:input class="tp-input -form-control" ref="TEI:seg[@type='details']">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-list-alt"/>
+                                                        </xf:label>
+                                                    </xf:input>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Link</label>
+                                                    <xf:input class="tp-input -form-control" ref="TEI:ptr/@ref">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-link"/>
+                                                        </xf:label>
+                                                    </xf:input>
+                                                </div>
+                                                <div class="tp-form-group-col">
+                                                    <label class="tp-label">Secondary Types</label>
+                                                    <xf:select1 class="tp-input -form-control" ref="@subtype">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-book"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-secondaryTypes')/option">
+                                                            <xf:label ref="."/>
+                                                            <xf:value ref="@value"/>
+                                                        </xf:itemset>
+                                                    </xf:select1>
+                                                </div>
+                                            </div>
+                                            <div class="tp-row">
+                                                <div class="form-group">
+                                                    <label class="tp-label-1-row-2-col">Source</label>
+                                                    <xf:select class="tp-input-1-row-2-col" ref="@ana" appearance="full">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-check"/>
+                                                        </xf:label>
+                                                        <xf:itemset nodeset="instance('i-comments')//option">
+                                                            <xf:label ref="."/>
+                                                            <xf:value ref="@value"/>
+                                                        </xf:itemset>
+                                                    </xf:select>
+                                                </div>
+                                            </div>
+                                            <div class="tp-row tp-repeat-buttons">
+                                                <div class="tp-repeat-button-right">
+                                                    <div class="tp-button-row tp-delete">
+                                                        <label>Delete</label>
+                                                        <xf:trigger class="-btn -btn-default">
+                                                            <xf:label class="input-group-addon">
+                                                                <i class="glyphicon glyphicon-trash"/>
+                                                            </xf:label>
+                                                            <xf:delete nodeset="//TEI:bibl[@type = 'auxiliary'][index('r-auxiliary')]"/>
+                                                        </xf:trigger>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </xf:repeat>
+                                    </xf:group>
+                                </section>
+                                <!-- // end secondary sources -->
                             </xf:group>
                         </section>
                     </div>
                 </div>
             </section>
             <!-- // end section names -->
-                                <div class="tp-section-divider"/>
 
             <!-- begin section relationships -->
             <section class="tp-section">
@@ -1335,11 +1379,32 @@
                         <fieldset class="form-horizontal">
                             <xf:group ref="//TEI:listRelation"><!-- RELATIONSHIPS -->
                                 <xf:group class="fieldset">
+                                    <div class="tp-row tp-repeat-add">
+                                        <xf:label class="tp-form-header">
+                                            <h3>Relationship</h3>
+                                        </xf:label>
+                                        <div class="tp-repeat-button-left">
+                                            <div class="tp-button-row tp-add">
+                                                <label>Add Relationship</label>
+                                                <xf:trigger class="-btn -btn-default ">
+                                                    <xf:label class="input-group-addon">
+                                                        <i class="glyphicon glyphicon-plus"/>
+                                                    </xf:label>
+                                                    <xf:insert context="//TEI:listRelation" nodeset="TEI:relation" origin="instance('i-template')//TEI:relation"/>
+                                                    <script>
+                                                        clearAndInitAutocompletes();
+                                                    </script>
+                                                </xf:trigger>
+                                            </div>
+                                        </div>
+                                    </div>
 
                                     <xf:repeat ref="TEI:relation" id="r-relation">
-                                        <xf:label class="tp-row tp-form-header">
-                                            <h4 class="col-md-2">Relationship</h4>
-                                        </xf:label>
+                                        <div class="tp-row tp-repeat-headline">
+                                            <xf:label class="tp-form-header">
+                                                <h4>Relationship Replicant</h4>
+                                            </xf:label>
+                                        </div>
                                         <xf:group ref=".">
                                             <xf:label/>
                                             <div class="tp-row">
@@ -1391,35 +1456,20 @@
                                                 </div>
                                             </div>
                                         </xf:group>
-                                    <div class="tp-row tp-repeat-buttons">
-                                        <div class="tp-repeat-button-left">
-                                            <div class="tp-button-row tp-add">
-                                                <label>Add Relationship</label>
-                                                <xf:trigger class="-btn -btn-default ">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-plus"/>
-                                                    </xf:label>
-                                                    <xf:insert context="//TEI:listRelation" nodeset="TEI:relation" origin="instance('i-template')//TEI:relation"/>
-                                                    <script>
-                                                        clearAndInitAutocompletes();
-                                                    </script>
-                                                </xf:trigger>
+                                        <div class="tp-row tp-repeat-buttons">
+                                            <div class="tp-repeat-button-right">
+                                                <div class="tp-button-row tp-delete">
+                                                    <label>Delete Relationship</label>
+                                                    <xf:trigger class="-btn -btn-default">
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-trash"/>
+                                                        </xf:label>
+                                                        <xf:delete nodeset="//TEI:relation[index('r-relation')]"/>
+                                                    </xf:trigger>
+                                                </div>
                                             </div>
                                         </div>
-                                        <div class="tp-repeat-button-right">
-                                            <div class="tp-button-row tp-delete">
-                                                <label>Delete Relationship</label>
-                                                <xf:trigger class="-btn -btn-default">
-                                                    <xf:label class="input-group-addon">
-                                                        <i class="glyphicon glyphicon-trash"/>
-                                                    </xf:label>
-                                                    <xf:delete nodeset="//TEI:relation[index('r-relation')]"/>
-                                                </xf:trigger>
-                                            </div>
-                                        </div>
-                                    </div>
                                     </xf:repeat>
-
                                 </xf:group>
                             </xf:group>
                         </fieldset>

--- a/resources/css/less/_theme.less
+++ b/resources/css/less/_theme.less
@@ -110,11 +110,15 @@ footer .poweredby img { width: 120px; }
 }
 
 .tp-repeat-buttons {
-  @media (min-width: @screen-sm-min) {
-    padding-top: 15px;
-  }
   .tp-button-row:not(:nth-of-type(2)) {
     &:extend(.form-group);
+  }
+}
+
+.tp-repeat-buttons,
+.tp-repeat-add {
+  @media (min-width: @screen-sm-min) {
+    padding: 20px 0;
   }
   .control-label {
     &:extend(.col-xs-12);
@@ -139,10 +143,16 @@ footer .poweredby img { width: 120px; }
       width: 100%;
   }
   label {
+    height: @input-height;
+    line-height: @input-height;
     display: block;
     @media (min-width: 768px) {
       float: left;
     }
+  }
+  h4 {
+    margin: 0;
+    line-height: @input-height;
   }
 }
 
@@ -155,14 +165,23 @@ footer .poweredby img { width: 120px; }
 
 // Bootstrap-style add/delete button
 .tp-repeat-button-left {
-  label {
-    text-align: left;
+  &> div {
     @media (min-width: 768px) {
-      width: 40%;
-      text-align: right;
+      margin-left: 60%;
+      margin-right: 0;
     }
     @media (min-width: 992px) {
-      width: 32%;
+      margin-left: 65%;
+    }
+  }
+
+  label {
+    text-align: right;
+    @media (min-width: 768px) {
+      width: 68%;
+    }
+    @media (min-width: 992px) {
+      width: 81%;
     }
   }
 }

--- a/resources/css/less/_theme.less
+++ b/resources/css/less/_theme.less
@@ -54,15 +54,16 @@ footer .poweredby img { width: 120px; }
 .tp-width-main {
   background-color: @color-form-bg;
   padding-top: 2rem;
-  padding-bottom: 2rem;
   &:last-of-type {
     @media (min-width: @screen-sm-min) {
       margin-bottom: 2rem;
     }
   }
+}
 
-  .tp-row:last-of-type .form-group:last-of-type {
-    //margin-bottom: 0;
+.tp-section-save {
+  .tp-width-main {
+    padding-bottom: 2rem;
   }
 }
 
@@ -118,7 +119,7 @@ footer .poweredby img { width: 120px; }
 .tp-repeat-buttons,
 .tp-repeat-add {
   @media (min-width: @screen-sm-min) {
-    padding: 20px 0;
+    padding: 0 0 10px 0;
   }
   .control-label {
     &:extend(.col-xs-12);
@@ -145,7 +146,6 @@ footer .poweredby img { width: 120px; }
     line-height: @input-height;
   }
   h3, h4 {
-    display: none;
     margin: 0;
     line-height: @input-height;
     width: 50%;
@@ -161,9 +161,36 @@ footer .poweredby img { width: 120px; }
   }
 }
 
+// Hide headline in original container and it only in replicant
+// Due to xform/betterform dynamic styling here applied with hard coded, static selectors!
+#C701,
+#C807,
+#C1192,
+#C1755,
+#C2414,
+#C2416,
+#C2502,
+#C1877,
+#C1891,
+#C1993,
+#C2173,
+#C2257,
+#C2308,
+#C2399,
+#C2487 {
+  &> .tp-repeat-headline {
+    display: none !important;
+  }
+}
+#C976 > div:nth-child(2) > div {
+  display: none;
+}
+
+.tp-repeat-headline {
+  display: inline;
+}
+
 .tp-repeat-add {
-  //padding-left: 15px;
-  //padding-right: 15px;
   max-width: 62.5rem;
   margin: 0;
 }
@@ -178,11 +205,9 @@ footer .poweredby img { width: 120px; }
 // Bootstrap-style add/delete button
 .tp-repeat-button-left {
   &> div {
-    //display: table;
     margin-left: auto;
     margin-right: 0;
     @media (min-width: 992px) {
-      //margin-left: 70%;
       padding-top: 4px;
     }
   }
@@ -192,9 +217,6 @@ footer .poweredby img { width: 120px; }
   &> div {
     margin-left: auto;
     margin-right: 0;
-    @media (min-width: 992px) {
-        //margin-left: 64%;
-    }
   }
   &> div > div {
     padding-left: 15px;
@@ -228,7 +250,6 @@ footer .poweredby img { width: 120px; }
     display: table-cell;
     padding-left: 15px;
   }
-
 }
 
 .tp-delete {
@@ -244,6 +265,33 @@ footer .poweredby img { width: 120px; }
   }
 }
 
+// Special for add buttons and headline and margins in Status section
+.status-section {
+  .xfGroup {
+    margin-top: 20px;
+  }
+  .tp-repeat-buttons {
+    padding: 10px 0 0;
+  }
+}
+
+.tp-repeat-add h3.status-headline {
+  float: none;
+}
+.tp-repeat-add>div.status-button-container {
+  width: 100%;
+  .tp-repeat-button-left {
+    .make-xs-column(6);
+    .make-sm-column(4);
+    padding-bottom: 20px;
+    span {
+      @media (max-width: @screen-xs) {
+        display: none;
+      }
+    }
+  }
+}
+
 .tp-add {
   .btn-default {
     background-color: lighten(@colorGreen, 20%);
@@ -255,6 +303,11 @@ footer .poweredby img { width: 120px; }
       background-color: darken(@colorGreen, 20%);
     }
   }
+}
+
+// secondary-sources
+.secondary-sources {
+  padding-top: 20px;
 }
 
 // Save/delete buttons in last section
@@ -277,16 +330,29 @@ footer .poweredby img { width: 120px; }
       }
     }
   }
+  .tp-repeat-buttons>div {
+    float: left !important;
+    @media (min-width: 768px) {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+  }
+  .tp-add {
+    margin-left: 13%;
+  }
+  @media (min-width: 992px) {
+    .tp-repeat-button-left label {
+      width: 50%;
+    }
+  }
 }
 
 // Headline in subform
 .tp-form-header {
   h3, h4 {
+    .make-xs-column(4);
     text-align: left;
     padding-left: 0;
-    @media (min-width: @screen-sm-min) {
-     // text-align: center;
-    }
     @media (min-width: @screen-md-min) {
       text-align: right;
     }

--- a/resources/css/less/_theme.less
+++ b/resources/css/less/_theme.less
@@ -134,26 +134,38 @@ footer .poweredby img { width: 120px; }
   &> div {
     position: relative;
     min-height: 1px;
-    @media (min-width: 768px) {
-      padding-left: 15px;
-      padding-right: 15px;
-    }
   }
   &> div {
-      width: 100%;
+    width: 50%;
+    margin-left: auto;
+    margin-right: 0;
   }
   label {
     height: @input-height;
     line-height: @input-height;
-    display: block;
-    @media (min-width: 768px) {
-      float: left;
-    }
   }
-  h4 {
+  h3, h4 {
+    display: none;
     margin: 0;
     line-height: @input-height;
+    width: 50%;
+    position: relative;
+    float: left;
+    min-height: 1px;
+    padding-right: 0;
+    padding-left: 0;
   }
+  .xfRepeatIndex h3,
+  .xfRepeatIndex h4 {
+    display: inline-block;
+  }
+}
+
+.tp-repeat-add {
+  //padding-left: 15px;
+  //padding-right: 15px;
+  max-width: 62.5rem;
+  margin: 0;
 }
 
 #C226 > div.tp-row.tp-repeat-buttons,
@@ -166,38 +178,26 @@ footer .poweredby img { width: 120px; }
 // Bootstrap-style add/delete button
 .tp-repeat-button-left {
   &> div {
-    @media (min-width: 768px) {
-      margin-left: 60%;
-      margin-right: 0;
-    }
+    //display: table;
+    margin-left: auto;
+    margin-right: 0;
     @media (min-width: 992px) {
-      margin-left: 65%;
-    }
-  }
-
-  label {
-    text-align: right;
-    @media (min-width: 768px) {
-      width: 68%;
-    }
-    @media (min-width: 992px) {
-      width: 81%;
+      //margin-left: 70%;
+      padding-top: 4px;
     }
   }
 }
 
 .tp-repeat-button-right {
   &> div {
-    @media (min-width: 768px) {
-        margin-left: 60%;
-        margin-right: 0;
-    }
+    margin-left: auto;
+    margin-right: 0;
     @media (min-width: 992px) {
-        margin-left: 65%;
+        //margin-left: 64%;
     }
   }
   &> div > div {
-    margin-left: auto;
+    padding-left: 15px;
     @media (min-width: 768px) {
       margin-left: 0;
     }
@@ -211,6 +211,24 @@ footer .poweredby img { width: 120px; }
       width: 81%;
     }
   }
+}
+
+.tp-delete,
+.tp-add {
+  display: table;
+  margin-left: auto;
+  margin-right: 0;
+
+  label {
+    display: table-cell;
+    text-align: right;
+    width: auto;
+  }
+  .xfControl {
+    display: table-cell;
+    padding-left: 15px;
+  }
+
 }
 
 .tp-delete {
@@ -267,7 +285,7 @@ footer .poweredby img { width: 120px; }
     text-align: left;
     padding-left: 0;
     @media (min-width: @screen-sm-min) {
-      text-align: center;
+     // text-align: center;
     }
     @media (min-width: @screen-md-min) {
       text-align: right;
@@ -324,10 +342,10 @@ footer .poweredby img { width: 120px; }
   padding-right: 0;
   @media (min-width: 768px) {
     float: left;
-    width: 75%;
+    width: 83%;
   }
   @media (min-width: 992px) {
-    width: 64%;
+    width: 72%;
   }
 }
 
@@ -353,9 +371,11 @@ footer .poweredby img { width: 120px; }
   min-height: 1px;
   @media (min-width: 768px) {
     float: left;
-    width: 75%;
+    width: 83%;
   }
   @media (min-width: 992px) {
-    width: 81.6666%;
+    width: 85.7%;
   }
 }
+
+

--- a/resources/css/less/_theme.less
+++ b/resources/css/less/_theme.less
@@ -136,8 +136,7 @@ footer .poweredby img { width: 120px; }
     }
   }
   &> div {
-      width: 50%;
-      float: left;
+      width: 100%;
   }
   label {
     display: block;
@@ -171,8 +170,11 @@ footer .poweredby img { width: 120px; }
 .tp-repeat-button-right {
   &> div {
     @media (min-width: 768px) {
-        margin-left: 30%;
+        margin-left: 60%;
         margin-right: 0;
+    }
+    @media (min-width: 992px) {
+        margin-left: 65%;
     }
   }
   &> div > div {


### PR DESCRIPTION
* All add buttons are placed next to the headline on the very right of the sections.  
* The status sections is customized: All add buttons are gathered in the section beginning instead of each subform.  
* Margins of sections have been updated.  
* Layout has been kept fully responsive.

As I want to merge directly to master, the original branch feat-headings-100 can be deleted after merge.