### PR TITLE
Fix autocompletes #118

### DIFF
--- a/editor.xhtml
+++ b/editor.xhtml
@@ -286,7 +286,7 @@
                                     <xf:repeat ref="TEI:listNym/TEI:nym[@type!='Roman']" id="r-name">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Nym Replicant</h4>
+                                                <h4>Nym</h4>
                                             </xf:label>
                                         </div>
 
@@ -396,7 +396,7 @@
                                             <xf:repeat ref="TEI:form[@type='attested']" id="r-nameForm">
                                                 <div class="tp-row tp-repeat-headline">
                                                     <xf:label class="tp-form-header">
-                                                        <h4>Attested Form Replicant</h4>
+                                                        <h4>Attested Form</h4>
                                                     </xf:label>
                                                 </div>
                                                 <xf:group ref=".">
@@ -506,7 +506,7 @@
                                             <div class="tp-row">
                                                 <div class="tp-row tp-repeat-headline">
                                                     <xf:label class="tp-form-header">
-                                                        <h4 class="col-md-6">Roman Name Replicant</h4>
+                                                        <h4 class="col-md-6">Roman Name</h4>
                                                     </xf:label>
                                                 </div>
 
@@ -622,7 +622,7 @@
                                     <xf:repeat ref="TEI:bibl[@type='primary']" id="r-primarySource">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Primary Sources Replicant</h4>
+                                                <h4>Primary Sources</h4>
                                             </xf:label>
                                         </div>
 
@@ -801,7 +801,7 @@
                                     <xf:repeat ref="TEI:state[@type='location']" id="r-place">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Places Replicant</h4>
+                                                <h4>Places</h4>
                                             </xf:label>
                                         </div>
                                         <xf:group ref=".">
@@ -984,7 +984,7 @@
                                     <xf:repeat ref="//TEI:trait[@type='status']" id="r-status">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Status Replicant</h4>
+                                                <h4>Status</h4>
                                             </xf:label>
                                         </div>
 
@@ -1037,7 +1037,7 @@
                                     <xf:repeat ref="//TEI:trait[@type='profession']" id="r-profession">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Profession Replicant</h4>
+                                                <h4>Profession</h4>
                                             </xf:label>
                                         </div>
                                         <xf:group ref=".">
@@ -1089,7 +1089,7 @@
                                     <xf:repeat ref="//TEI:trait[@type='office']" id="r-office">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Office Replicant</h4>
+                                                <h4>Office</h4>
                                             </xf:label>
                                         </div>
                                         <xf:group ref=".">
@@ -1142,7 +1142,7 @@
                                     <xf:repeat ref="//TEI:trait[@type='religion']" id="r-religion">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Religion Replicant</h4>
+                                                <h4>Religion</h4>
                                             </xf:label>
                                         </div>
                                         <xf:group ref=".">
@@ -1194,7 +1194,7 @@
                                     <xf:repeat ref="//TEI:trait[@type='Roman']" id="r-Roman">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Roman World Replicant</h4>
+                                                <h4>Roman World</h4>
                                             </xf:label>
                                         </div>
                                         <xf:group ref=".">
@@ -1268,7 +1268,7 @@
                                         <xf:repeat ref="TEI:bibl[@type = 'auxiliary']" id="r-auxiliary">
                                             <div class="tp-row tp-repeat-headline">
                                                 <xf:label class="tp-form-header">
-                                                    <h4>Secondary Sources Replicant</h4>
+                                                    <h4>Secondary Sources</h4>
                                                 </xf:label>
                                             </div>
 
@@ -1400,7 +1400,7 @@
                                     <xf:repeat ref="TEI:relation" id="r-relation">
                                         <div class="tp-row tp-repeat-headline">
                                             <xf:label class="tp-form-header">
-                                                <h4>Relationship Replicant</h4>
+                                                <h4>Relationship</h4>
                                             </xf:label>
                                         </div>
                                         <xf:group ref=".">

--- a/editor.xhtml
+++ b/editor.xhtml
@@ -14,6 +14,8 @@
             <xf:model id="model-1">
                 <xf:instance xmlns="" id="i-default" src="resources/xml/teiPersonTemplate.xml"/>
                 <xf:bind ref="//TEI:nym[@type ne 'Roman']/@nymRef" constraint="string-length(.) &gt; 0" type="xs:string"/>
+                <xf:bind ref="//TEI:bibl[@type='primary'][index('r-primarySource')]/TEI:ref/@target" constraint="string-length(.) &gt; 0" type="xs:string"/>
+                <xf:bind ref="//TEI:bibl[index('r-primarySource')]/TEI:ref/@target" constraint="string-length(.) &gt; 0" type="xs:string"/>
                 <xf:bind ref="//TEI:bibl[@type='primary']/TEI:ref[index('r-primarySource')]" constraint="not(boolean-from-string(instance('i-biblPattern')/validate))"/>
                 <xf:instance xmlns="" id="i-template" src="resources/xml/personTemplate.xml"/>
                 <xf:instance xmlns="" id="i-volumes" src="resources/xml/volumes.xml"/>
@@ -289,26 +291,21 @@
                                         </div>
 
                                         <xf:group ref=".">
-                                           <div class="tp-row">
-                                                <div class="tp-form-group-col">
+                                            <div class="tp-row">
+                                                <div class="tp-form-group-col tp-validation">
                                                     <label class="tp-label">Select name</label>
-                                                        <xf:input ref="@nymRef" class="-custom-alert">
-                                                            <xf:action ev:event="nyms_autocomplete-callback">
-                                                                <xf:setvalue ref="." value="event('termValue')"/>
-                                                            </xf:action>
-                                                            <xf:label class="input-group-addon">
-                                                                <i class="glyphicon glyphicon-book"/>
-                                                            </xf:label>
-                                                            <xf:hint>normalized form</xf:hint>
-                                                            <xf:alert>blah</xf:alert>
-                                                        </xf:input>
+                                                    <xf:input ref="@nymRef" class="-custom-alert">
+                                                        <xf:action ev:event="nyms_autocomplete-callback">
+                                                            <xf:setvalue ref="." value="event('termValue')"/>
+                                                        </xf:action>
+                                                        <xf:label class="input-group-addon">
+                                                            <i class="glyphicon glyphicon-book"/>
+                                                        </xf:label>
+                                                        <xf:hint>normalized form</xf:hint>
+                                                        <xf:alert>Please insert a term</xf:alert>
+                                                    </xf:input>
                                                     <input type="hidden" class="tp-input" data-function="nyms_autocomplete" placeholder="Type to search name" autocomplete="off"/>
-<!--
-<xf:output ref="@nymRef">
-                                                    <xf:label> </xf:label>
-                                                        <xf:alert>blllah</xf:alert>
-                                                    </xf:output>
--->                                                </div>
+                                                </div>
                                                 <div class="tp-form-group-col">
                                                     <label class="tp-label">Certainty</label>
                                                     <xf:select1 class="tp-input -form-control" ref="//TEI:listNym/TEI:nym/@cert">
@@ -632,9 +629,9 @@
                                         <xf:group ref=".">
                                             <xf:label/>
                                             <div class="tp-row">
-                                                <div class="tp-form-group-col">
+                                                <div class="tp-form-group-col tp-validation">
                                                     <label class="tp-label" tooltip="ref">Reference Abbr.</label>
-                                                    <xf:input class="hidden" ref="TEI:ref/@target">
+                                                    <xf:input class="-custom-alert" ref="TEI:ref/@target">
                                                         <xf:action ev:event="reference_autocomplete-callback">
                                                             <xf:setvalue ref="." value="event('termValue')"/>
                                                         </xf:action>
@@ -642,6 +639,7 @@
                                                             <i class="glyphicon glyphicon-book"/>
                                                         </xf:label>
                                                         <xf:hint>reference abbreviation</xf:hint>
+                                                        <xf:alert>Please insert term</xf:alert>
                                                     </xf:input>
                                                     <input type="hidden" class="tp-input" data-function="reference_autocomplete" placeholder="Type to search reference abbreviation" autocomplete="off"/>
 
@@ -1246,7 +1244,6 @@
 
                                 <div class="tp-section-divider"/>
 
-
                                 <!-- SECONDARY SOURCES -->
                                 <section class="secondary-sources">
                                     <div class="tp-row tp-repeat-add">
@@ -1276,9 +1273,9 @@
                                             </div>
 
                                             <div class="tp-row">
-                                                <div class="tp-form-group-col">
+                                                <div class="tp-form-group-col tp-validation">
                                                     <label class="tp-label" tooltip="ref">Reference Abbr.</label>
-                                                    <xf:input class="hidden" ref="TEI:ref/@target">
+                                                    <xf:input class="-custom-alert" ref="TEI:ref/@target">
                                                         <xf:action ev:event="reference_autocomplete-callback">
                                                             <xf:setvalue ref="." value="event('termValue')"/>
                                                         </xf:action>
@@ -1286,6 +1283,7 @@
                                                             <i class="glyphicon glyphicon-search"/>
                                                         </xf:label>
                                                         <xf:hint>reference abbreviation</xf:hint>
+                                                        <xf:alert>Please insert term</xf:alert>
                                                     </xf:input>
                                                     <input type="hidden" class="tp-input" data-function="reference_autocomplete" placeholder="Type to search reference abbreviation" autocomplete="off"/>
                                                     <xf:trigger class="hidden reference_autocomplete">

--- a/resources/css/less/_theme.less
+++ b/resources/css/less/_theme.less
@@ -161,31 +161,6 @@ footer .poweredby img { width: 120px; }
   }
 }
 
-// Hide headline in original container and it only in replicant
-// Due to xform/betterform dynamic styling here applied with hard coded, static selectors!
-#C701,
-#C807,
-#C1192,
-#C1755,
-#C2414,
-#C2416,
-#C2502,
-#C1877,
-#C1891,
-#C1993,
-#C2173,
-#C2257,
-#C2308,
-#C2399,
-#C2487 {
-  &> .tp-repeat-headline {
-    display: none !important;
-  }
-}
-#C976 > div:nth-child(2) > div {
-  display: none;
-}
-
 .tp-repeat-headline {
   display: inline;
 }

--- a/resources/css/less/_xform-overrides.less
+++ b/resources/css/less/_xform-overrides.less
@@ -60,3 +60,23 @@ span.xfControl {
 .dijitContentPane {
   overflow: visible;
 }
+
+// Alert messages in "select2" inputs, hide xform css, show only its alertbox
+.tp-validation {
+  div.xfInvalid,
+  div.r-auxiliary-5 {
+    position: absolute;
+    top: -31px;
+    left: 153px;
+    z-index: 15;
+
+    label.xfLabel.aDefault.xfEnabled {
+      display: none;
+    }
+  }
+
+  input.custom-alert {
+    opacity: 0;
+    width: 0;
+  }
+}

--- a/resources/css/less/_xform-overrides.less
+++ b/resources/css/less/_xform-overrides.less
@@ -64,7 +64,8 @@ span.xfControl {
 // Alert messages in "select2" inputs, hide xform css, show only its alertbox
 .tp-validation {
   div.xfInvalid,
-  div.r-auxiliary-5 {
+  div.r-auxiliary-5,
+  div.r-name-5 {
     position: absolute;
     top: -31px;
     left: 153px;

--- a/resources/css/less/_xform-overrides.less
+++ b/resources/css/less/_xform-overrides.less
@@ -65,7 +65,8 @@ span.xfControl {
 .tp-validation {
   div.xfInvalid,
   div.r-auxiliary-5,
-  div.r-name-5 {
+  div.r-name-5,
+  div.r-primarySource-5 {
     position: absolute;
     top: -31px;
     left: 153px;


### PR DESCRIPTION
### Fixes for #118 
* add new bindings for primary and secondary sources to autocomplete inputs
* add alert element to nym, primary and secondary sources inputs
* hide the underlying inputs from being displayed or being visible

### Additional fixes for #100 
My solution for hiding headlines in the prototype only worked with hard codes IDs, because with all the background betterform processing of classnames and IDs, there is no distinction possible between replicated containers and prototypes possible, or to address a precise css selector for only those. For a quick solution, I displayed all headlines, regardless of prototype and replicant for now.